### PR TITLE
chore: DNS設定をTerraformで管理できるようにする/PRベースでActionsから設定を反映できるようにする

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,37 @@
+name: Terraform Apply
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "terraform/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terraform-apply
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: terraform
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TFSTATE_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TFSTATE_R2_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+
+      - name: terraform init
+        run: terraform init
+
+      - name: terraform apply
+        run: terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,101 @@
+name: Terraform Plan
+
+on:
+  pull_request:
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform-plan.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+defaults:
+  run:
+    working-directory: terraform
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.TFSTATE_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TFSTATE_R2_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+
+      - name: terraform fmt check
+        id: fmt
+        run: terraform fmt -check -diff
+        continue-on-error: true
+
+      - name: terraform init
+        run: terraform init
+
+      - name: terraform validate
+        run: terraform validate -no-color
+
+      - name: terraform plan
+        id: plan
+        run: terraform plan -no-color -input=false
+        continue-on-error: true
+
+      - name: Comment plan result on PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PLAN: "${{ steps.plan.outputs.stdout }}${{ steps.plan.outputs.stderr }}"
+          FMT_OUTCOME: "${{ steps.fmt.outcome }}"
+          PLAN_OUTCOME: "${{ steps.plan.outcome }}"
+        with:
+          script: |
+            const marker = "<!-- terraform-plan-comment -->";
+            let plan = process.env.PLAN || "";
+            const limit = 60000;
+            if (plan.length > limit) {
+              plan = plan.slice(0, limit) + "\n\n... (出力が長いため省略)";
+            }
+
+            const body = `${marker}
+            #### Terraform Plan結果
+
+            - fmt: \`${process.env.FMT_OUTCOME}\`
+            - plan: \`${process.env.PLAN_OUTCOME}\`
+
+            <details><summary>plan出力を表示</summary>
+
+            \`\`\`
+            ${plan}
+            \`\`\`
+
+            </details>
+
+            *Workflow: \`${{ github.workflow }}\` / Commit: \`${{ github.sha }}\`*`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail if plan failed
+        if: steps.plan.outcome == 'failure'
+        run: exit 1

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+terraform = "1.15.7"

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,19 @@
+# state保存先: Cloudflare R2
+terraform {
+  backend "s3" {
+    bucket = "dns-iac-tfstate"
+    key    = "terraform.tfstate"
+    region = "auto"
+
+    endpoints = {
+      s3 = "https://f208797981323b5cf2014d1be7fcfaff.r2.cloudflarestorage.com"
+    }
+
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    use_lockfile                = true
+  }
+}

--- a/terraform/r2.tf
+++ b/terraform/r2.tf
@@ -1,0 +1,6 @@
+# terraformのstateを保存するR2バケット
+resource "cloudflare_r2_bucket" "tfstate" {
+  account_id = var.cloudflare_account_id
+  name       = "dns-iac-tfstate"
+  location   = "APAC"
+}

--- a/terraform/records.tf
+++ b/terraform/records.tf
@@ -1,19 +1,7 @@
 resource "cloudflare_dns_record" "terraform_managed_resource_c43c2de31a0100c1497475ffb8f1a736_0" {
   comment  = "Gitea(PROD)用/管理者: @laminne"
-  content  = "116.80.80.106"
+  content  = "133.18.124.103"
   name     = "git.poporon.org"
-  proxied  = false
-  tags     = []
-  ttl      = 1
-  type     = "A"
-  zone_id  = "878133051abf4697f6c4151e0b8b425a"
-  settings = {}
-}
-
-resource "cloudflare_dns_record" "terraform_managed_resource_8f90ea62a94daeb74c7a6a8eb84f3d44_1" {
-  comment  = "Authentik(PROD)用/管理者: @laminne"
-  content  = "172.234.80.75"
-  name     = "id.poporon.org"
   proxied  = false
   tags     = []
   ttl      = 1
@@ -24,24 +12,12 @@ resource "cloudflare_dns_record" "terraform_managed_resource_8f90ea62a94daeb74c7
 
 resource "cloudflare_dns_record" "terraform_managed_resource_d1c7196539db6fbe870343dd28af21ad_2" {
   comment  = "ilu-t用 / 管理: @laminne"
-  content  = "116.80.80.106"
+  content  = "133.18.124.103"
   name     = "ilu-t.poporon.org"
   proxied  = true
   tags     = []
   ttl      = 1
   type     = "A"
-  zone_id  = "878133051abf4697f6c4151e0b8b425a"
-  settings = {}
-}
-
-resource "cloudflare_dns_record" "terraform_managed_resource_b58f9a72876bd7a7d0d6ba1ddbc0878b_3" {
-  comment  = "Gitea(PROD)用/管理者: @laminne"
-  content  = "2400:8905::2000:daff:fe2a:9bbd"
-  name     = "git.poporon.org"
-  proxied  = false
-  tags     = []
-  ttl      = 1
-  type     = "AAAA"
   zone_id  = "878133051abf4697f6c4151e0b8b425a"
   settings = {}
 }
@@ -222,7 +198,7 @@ resource "cloudflare_dns_record" "terraform_managed_resource_797304e6d54907c044c
 }
 
 resource "cloudflare_dns_record" "terraform_managed_resource_91369f06f96dbb40a603129aa23bfb76_18" {
-  content  = "\"v=DMARC1; p=none; rua=mailto:78a84b2960ba4f1ba848a494f6462e87@dmarc-reports.cloudflare.net\""
+  content  = "\"v=DMARC1; p=reject; rua=mailto:78a84b2960ba4f1ba848a494f6462e87@dmarc-reports.cloudflare.net\""
   name     = "_dmarc.poporon.org"
   proxied  = false
   tags     = []

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,4 @@
+variable "cloudflare_account_id" {
+  description = "f208797981323b5cf2014d1be7fcfaff"
+  type        = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,4 @@
 variable "cloudflare_account_id" {
-  description = "f208797981323b5cf2014d1be7fcfaff"
-  type        = string
+  default = "f208797981323b5cf2014d1be7fcfaff"
+  type    = string
 }


### PR DESCRIPTION
- DNSをTerraformで管理できるように、workflowを整備しました
  - すでに用意していたレコードの一覧は古くなっていたので最新に更新
  - `ilu-t.poporon.org.`は値を更新、`id.poporon.org.`はレコードを削除した