### PR TITLE
feat: 旧GiteaからForgejoへ移行する

### DIFF
--- a/k8s/apps/forgejo/README.md
+++ b/k8s/apps/forgejo/README.md
@@ -1,0 +1,89 @@
+# Forgejoの初回デプロイ
+
+Forgejoは旧Giteaデータの移行が終わるまで0 replicasでデプロイされる。
+`kustomization.yaml`末尾のpatchがDeploymentを停止している。
+
+## Vault
+
+Vaultの`forgejo`に次のpropertyを登録する。
+
+- `database_password`
+- `secret_key`
+- `internal_token`
+- `oauth2_jwt_secret`
+- `lfs_jwt_secret`
+
+`secret_key`は旧Giteaの`security.SECRET_KEY`を引き継ぐ。
+既存の暗号化済みデータを復号できなくなるため、新しい値へ変更しない。
+
+残りのtokenも、既存tokenを維持する場合は旧`app.ini`の値を引き継ぐ。
+
+Vaultの`valkey`には、URLへ埋め込める十分に長い`password`を登録する。
+External Secrets OperatorがURLエンコードするため、記号を含むpasswordも利用できる。
+
+## データ移行
+
+旧Giteaを停止し、PostgreSQLの`gitea` databaseへの接続が残っていないことを確認したうえで、`gitea`をtemplateにした`forgejo` databaseを作成する。
+
+```console
+CREATE DATABASE forgejo TEMPLATE gitea OWNER gitea;
+```
+
+`TEMPLATE`はcopy元databaseへの接続が一切無い状態でないと失敗するため、旧Giteaの停止と接続確認が前提になる。
+また`gitea` USERはCREATEDB権限を持たないため、`postgres`等の管理者roleで実行する。
+
+Forgejoの`kustomization.yaml`は`database.NAME`にこの`forgejo` databaseを指す。
+元の`gitea` databaseはコピー後も変更されないため、Forgejoの初回起動によるschema migrationが失敗しても、`forgejo` databaseを作り直せばやり直せる。
+
+同じ停止状態で、旧Giteaのデータを保持するLonghorn volume `gitea`のsnapshotも、Longhorn UIまたは`longhorn.io/v1beta2 Snapshot`リソースで取得する。
+
+取得したsnapshot名を[source-volume.yaml](./../../migrations/gitea-to-forgejo/source-volume.yaml)の`dataSource`（`snap://gitea/<snapshot名>`）へ反映する。
+このsnapshot名は日時を含む固定値であり使い回せないため、migration Jobを適用するたびに実際に取得したsnapshotの名前へ書き換える。
+`source-pv.yaml`/`source-pvc.yaml`の`storage`容量も、必要に応じて`gitea` volumeの実サイズに合わせて調整する。
+
+旧GiteaからForgejo 15へ直接更新できるversionかも、初回起動前にForgejoのupgrade pathで確認する。
+直接更新できない場合は、対応する中間versionを経由する。
+
+Argo CDが`longhorn-retain`、Valkey、ForgejoのPVCを作成し、両PVCが`Bound`になった後、migration Jobを手動で適用する。
+
+```console
+kubectl apply -k k8s/migrations/gitea-to-forgejo
+kubectl wait --for=condition=complete --timeout=10m job/gitea-to-forgejo -n forgejo
+kubectl logs job/gitea-to-forgejo -n forgejo
+kubectl delete -k k8s/migrations/gitea-to-forgejo
+```
+
+Jobは保全snapshotから一時Longhorn volumeをcloneし、repository、LFS、attachment、avatar、package、Actionsデータを新しいRWX volumeへコピーする。
+旧`app.ini`、session、queue、indexer、SSH host keyはコピーしない。
+
+Jobはin-progress markerを使うため、コピー中に失敗した場合は同じJobのretryで再開できる。
+complete markerがある状態では再実行しない。
+
+一時リソースを削除しても、元の`gitea` volumeとsnapshotは残る。
+
+## 起動
+
+移行後に`kustomization.yaml`末尾のDeployment patchを削除する。
+Argo CDの同期後、Forgejoが1 replicaで起動してDB migrationを実行する。
+
+HTTPSの動作、repository、avatar、clone、pushを確認するまで、旧Gitea volumeとsnapshotは削除しない。
+同じ期間、PostgreSQLの元`gitea` databaseも削除しない。
+
+SSH ServiceはClusterIPであり、クラスタ外には公開していない。
+SSHを公開するときはTraefikのTCP entrypointとSSH host keyの移行またはfingerprint変更の周知が必要になる。
+
+## Secretの更新
+
+External Secrets OperatorによるSecret更新だけでは、実行中のForgejoとValkeyに新しい値は反映されない。
+passwordやtokenを変更するときは、PostgreSQL、Valkey、Vaultを整合させたうえで両Deploymentを計画的に再起動する。
+
+## 将来の複数replica化
+
+Forgejo chartは複数replicaを正式なHA構成として保証していない。
+検証する場合は、少なくとも次の変更が必要になる。
+
+- ValkeyをSentinelまたはCluster構成へ変更する
+- `cron.GIT_GC_REPOS.ENABLED`を`false`にする
+- DB migrationを単一PodまたはJobで実行する
+- PodDisruptionBudgetを追加する
+- RWX障害時と同時push時の動作を確認する

--- a/k8s/apps/forgejo/kustomization.yaml
+++ b/k8s/apps/forgejo/kustomization.yaml
@@ -1,0 +1,184 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: forgejo
+resources:
+  - ./resources/namespace.yaml
+  - ./resources/external-secret.yaml
+  - ./resources/certificate.yaml
+helmCharts:
+  - name: forgejo
+    repo: oci://code.forgejo.org/forgejo-helm
+    version: "17.1.4"
+    releaseName: forgejo
+    namespace: forgejo
+    valuesInline:
+      replicaCount: 1
+
+      strategy:
+        type: Recreate
+
+      image:
+        rootless: true
+
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+
+      podSecurityContext:
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+
+      persistence:
+        enabled: true
+        create: true
+        mount: true
+        claimName: forgejo-shared-storage
+        size: 20Gi
+        accessModes:
+          - ReadWriteMany
+        storageClass: longhorn-retain
+
+      service:
+        http:
+          type: ClusterIP
+          port: 3000
+        ssh:
+          type: ClusterIP
+          port: 22
+
+      ingress:
+        enabled: true
+        className: traefik
+        annotations:
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+          traefik.ingress.kubernetes.io/router.tls: "true"
+        hosts:
+          - host: git.poporon.org
+            paths:
+              - path: /
+                pathType: Prefix
+                port: http
+        tls:
+          - secretName: forgejo-tls
+            hosts:
+              - git.poporon.org
+
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: forgejo
+
+      gitea:
+        admin:
+          username: ""
+          password: ""
+
+        additionalConfigFromEnvs:
+          - name: FORGEJO__DATABASE__PASSWD
+            valueFrom:
+              secretKeyRef:
+                name: forgejo-config
+                key: database-password
+          - name: FORGEJO__SECURITY__SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: forgejo-config
+                key: secret-key
+          - name: FORGEJO__SECURITY__INTERNAL_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: forgejo-config
+                key: internal-token
+          - name: FORGEJO__OAUTH2__JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: forgejo-config
+                key: oauth2-jwt-secret
+          - name: FORGEJO__SERVER__LFS_JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: forgejo-config
+                key: lfs-jwt-secret
+          - name: FORGEJO__QUEUE__CONN_STR
+            valueFrom:
+              secretKeyRef:
+                name: forgejo-config
+                key: valkey-queue-uri
+          - name: FORGEJO__CACHE__HOST
+            valueFrom:
+              secretKeyRef:
+                name: forgejo-config
+                key: valkey-cache-uri
+          - name: FORGEJO__SESSION__PROVIDER_CONFIG
+            valueFrom:
+              secretKeyRef:
+                name: forgejo-config
+                key: valkey-session-uri
+
+        config:
+          APP_NAME: Forgejo
+          RUN_MODE: prod
+          repository:
+            ROOT: /data/git/repositories
+          server:
+            APP_DATA_PATH: /data/gitea
+            DOMAIN: git.poporon.org
+            ROOT_URL: https://git.poporon.org/
+            SSH_DOMAIN: git.poporon.org
+            SSH_PORT: 22
+            SSH_LISTEN_PORT: 2222
+            LFS_START_SERVER: true
+          lfs:
+            PATH: /data/git/lfs
+          database:
+            DB_TYPE: postgres
+            HOST: 10.33.2.25:5432
+            NAME: forgejo
+            USER: gitea
+            SSL_MODE: disable
+          queue:
+            TYPE: redis
+          cache:
+            ENABLED: true
+            ADAPTER: redis
+          session:
+            PROVIDER: redis
+          indexer:
+            ISSUE_INDEXER_TYPE: db
+            REPO_INDEXER_ENABLED: false
+          metrics:
+            ENABLED: true
+
+        metrics:
+          enabled: true
+          serviceMonitor:
+            enabled: true
+
+      test:
+        enabled: false
+
+# Keep Forgejo stopped until the snapshot migration and Vault setup are complete.
+patches:
+  - target:
+      kind: Deployment
+      name: forgejo
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 0

--- a/k8s/apps/forgejo/resources/certificate.yaml
+++ b/k8s/apps/forgejo/resources/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: forgejo
+  namespace: forgejo
+spec:
+  secretName: forgejo-tls
+  dnsNames:
+    - git.poporon.org
+  issuerRef:
+    name: cluster-issuer-poporon-org
+    kind: ClusterIssuer

--- a/k8s/apps/forgejo/resources/external-secret.yaml
+++ b/k8s/apps/forgejo/resources/external-secret.yaml
@@ -1,0 +1,48 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: forgejo-config
+  namespace: forgejo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault
+  target:
+    name: forgejo-config
+    template:
+      engineVersion: v2
+      data:
+        database-password: "{{ .database_password }}"
+        secret-key: "{{ .secret_key }}"
+        internal-token: "{{ .internal_token }}"
+        oauth2-jwt-secret: "{{ .oauth2_jwt_secret }}"
+        lfs-jwt-secret: "{{ .lfs_jwt_secret }}"
+        valkey-queue-uri: "redis://default:{{ .valkey_password | urlquery }}@valkey.valkey.svc.cluster.local:6379/0"
+        valkey-cache-uri: "redis://default:{{ .valkey_password | urlquery }}@valkey.valkey.svc.cluster.local:6379/1"
+        valkey-session-uri: "redis://default:{{ .valkey_password | urlquery }}@valkey.valkey.svc.cluster.local:6379/2"
+  data:
+    - secretKey: database_password
+      remoteRef:
+        key: forgejo
+        property: database_password
+    - secretKey: secret_key
+      remoteRef:
+        key: forgejo
+        property: secret_key
+    - secretKey: internal_token
+      remoteRef:
+        key: forgejo
+        property: internal_token
+    - secretKey: oauth2_jwt_secret
+      remoteRef:
+        key: forgejo
+        property: oauth2_jwt_secret
+    - secretKey: lfs_jwt_secret
+      remoteRef:
+        key: forgejo
+        property: lfs_jwt_secret
+    - secretKey: valkey_password
+      remoteRef:
+        key: valkey
+        property: password

--- a/k8s/apps/forgejo/resources/namespace.yaml
+++ b/k8s/apps/forgejo/resources/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: forgejo

--- a/k8s/apps/valkey/kustomization.yaml
+++ b/k8s/apps/valkey/kustomization.yaml
@@ -1,0 +1,99 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: valkey
+resources:
+  - ./resources/namespace.yaml
+  - ./resources/external-secret.yaml
+  - ./resources/network-policy.yaml
+helmCharts:
+  - name: valkey
+    repo: https://valkey.io/valkey-helm/
+    version: "0.11.0"
+    releaseName: valkey
+    namespace: valkey
+    valuesInline:
+      fullnameOverride: valkey
+
+      auth:
+        enabled: true
+        usersExistingSecret: valkey
+        aclUsers:
+          default:
+            permissions: "~* &* +@all"
+
+      dataStorage:
+        enabled: true
+        requestedSize: 1Gi
+        className: longhorn-retain
+        accessModes:
+          - ReadWriteOnce
+        keepPvc: true
+
+      deploymentStrategy: Recreate
+
+      readinessProbe:
+        enabled: true
+        customProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -ec
+              - VALKEYCLI_AUTH="$(cat /valkey-users-secret/default)" valkey-cli ping | grep -qx PONG
+
+      startupProbe:
+        enabled: true
+        customProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -ec
+              - VALKEYCLI_AUTH="$(cat /valkey-users-secret/default)" valkey-cli ping | grep -qx PONG
+
+      livenessProbe:
+        enabled: true
+        customProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -ec
+              - VALKEYCLI_AUTH="$(cat /valkey-users-secret/default)" valkey-cli ping | grep -qx PONG
+
+      extraValkeySecrets:
+        - name: valkey
+          mountPath: /valkey-users-secret
+
+      valkeyConfig: |
+        appendonly yes
+        appendfsync everysec
+
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 256Mi
+
+      metrics:
+        enabled: true
+        exporter:
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+        serviceMonitor:
+          enabled: true
+
+patches:
+  - target:
+      kind: Pod
+      name: valkey-test-auth-existing
+    patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: valkey-test-auth-existing

--- a/k8s/apps/valkey/resources/external-secret.yaml
+++ b/k8s/apps/valkey/resources/external-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: valkey
+  namespace: valkey
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault
+  target:
+    name: valkey
+  data:
+    - secretKey: default
+      remoteRef:
+        key: valkey
+        property: password

--- a/k8s/apps/valkey/resources/namespace.yaml
+++ b/k8s/apps/valkey/resources/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: valkey

--- a/k8s/apps/valkey/resources/network-policy.yaml
+++ b/k8s/apps/valkey/resources/network-policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: valkey
+  namespace: valkey
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: valkey
+      app.kubernetes.io/name: valkey
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: forgejo
+      ports:
+        - protocol: TCP
+          port: 6379
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: prometheus
+      ports:
+        - protocol: TCP
+          port: 9121

--- a/k8s/migrations/gitea-to-forgejo/kustomization.yaml
+++ b/k8s/migrations/gitea-to-forgejo/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - source-volume.yaml
+  - source-pv.yaml
+  - source-pvc.yaml
+  - migration-job.yaml

--- a/k8s/migrations/gitea-to-forgejo/migration-job.yaml
+++ b/k8s/migrations/gitea-to-forgejo/migration-job.yaml
@@ -1,0 +1,70 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gitea-to-forgejo
+  namespace: forgejo
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: alpine:3.22.1
+          command:
+            - /bin/sh
+            - -euc
+            - |
+              test -d /source/git/repositories
+              test ! -e /destination/.gitea-migration-complete
+
+              if [ ! -e /destination/.gitea-migration-in-progress ]; then
+                test -z "$(find /destination/git/repositories -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)"
+                touch /destination/.gitea-migration-in-progress
+              fi
+
+              for path in \
+                git/repositories \
+                git/lfs \
+                gitea/actions_artifacts \
+                gitea/actions_log \
+                gitea/attachments \
+                gitea/avatars \
+                gitea/packages \
+                gitea/repo-archive \
+                gitea/repo-avatars
+              do
+                if [ -d "/source/${path}" ]; then
+                  mkdir -p "/destination/${path}"
+                  cp -a "/source/${path}/." "/destination/${path}/"
+                fi
+              done
+
+              mv /destination/.gitea-migration-in-progress /destination/.gitea-migration-complete
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: source
+              mountPath: /source
+              readOnly: true
+            - name: destination
+              mountPath: /destination
+      volumes:
+        - name: source
+          persistentVolumeClaim:
+            claimName: gitea-forgejo-migration-source
+            readOnly: true
+        - name: destination
+          persistentVolumeClaim:
+            claimName: forgejo-shared-storage

--- a/k8s/migrations/gitea-to-forgejo/source-pv.yaml
+++ b/k8s/migrations/gitea-to-forgejo/source-pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: gitea-forgejo-migration-source
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: longhorn-static
+  csi:
+    driver: driver.longhorn.io
+    volumeHandle: gitea-forgejo-migration-source

--- a/k8s/migrations/gitea-to-forgejo/source-pvc.yaml
+++ b/k8s/migrations/gitea-to-forgejo/source-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: gitea-forgejo-migration-source
+  namespace: forgejo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: longhorn-static
+  volumeName: gitea-forgejo-migration-source

--- a/k8s/migrations/gitea-to-forgejo/source-volume.yaml
+++ b/k8s/migrations/gitea-to-forgejo/source-volume.yaml
@@ -1,0 +1,14 @@
+apiVersion: longhorn.io/v1beta2
+kind: Volume
+metadata:
+  name: gitea-forgejo-migration-source
+  namespace: longhorn-system
+spec:
+  accessMode: rwo
+  cloneMode: full-copy
+  dataEngine: v1
+  dataLocality: disabled
+  dataSource: snap://gitea/gitea-pre-forgejo-20260814t121255z
+  frontend: blockdev
+  numberOfReplicas: 1
+  size: "10737418240"

--- a/k8s/system/longhorn/kustomization.yaml
+++ b/k8s/system/longhorn/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://raw.githubusercontent.com/longhorn/longhorn/v1.11.1/deploy/longhorn.yaml
+  - ./resources/storage-class-retain.yaml
+  - ./resources/storage-class-static.yaml

--- a/k8s/system/longhorn/resources/storage-class-retain.yaml
+++ b/k8s/system/longhorn/resources/storage-class-retain.yaml
@@ -1,0 +1,16 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-retain
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "3"
+  staleReplicaTimeout: "30"
+  fsType: ext4
+  dataLocality: disabled
+  disableRevisionCounter: "true"
+  dataEngine: v1
+  backupTargetName: default

--- a/k8s/system/longhorn/resources/storage-class-static.yaml
+++ b/k8s/system/longhorn/resources/storage-class-static.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-static
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Retain
+volumeBindingMode: Immediate


### PR DESCRIPTION
## 概要

- 旧クラスタのGiteaのデータを吸い出したので、新クラスタへの移行と同時にForgejoにしてみます
- `longhorn-retain` / `longhorn-static` StorageClassを追加（`longhorn-static` grafanaで使うと定義したが未使用）
- Valkeyを追加（Forgejoのqueue/cacheバックエンド）
- Forgejoを追加。データ移行が終わるまで0 replicasでデプロイ
  - Postgresはコピー済みなのでマイグレーション失敗リスクを回避するために起動を止める
- gitea→forgejo移行用のmigration Job一式を追加（repository/LFS/attachment/avatar/package/Actionsデータを新しい領域にコピーする)

## マージ後の作業
- [ ] Argo CD同期後、両PVCが`Bound`になったことを確認してmigration Jobを手動適用
- [ ] 動作確認後、Forgejoの`kustomization.yaml`末尾にあるDeployment停止patchを削除

事前調査/マニフェストのチェック: Generated with [Claude Code](https://claude.com/claude-code)