### PR TITLE
fix(longhorn): longhorn-static StorageClassの定義をクラスタの実態に合わせる

### DIFF
--- a/k8s/system/longhorn/resources/storage-class-static.yaml
+++ b/k8s/system/longhorn/resources/storage-class-static.yaml
@@ -4,5 +4,7 @@ metadata:
   name: longhorn-static
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
-reclaimPolicy: Retain
+reclaimPolicy: Delete
 volumeBindingMode: Immediate
+parameters:
+  staleReplicaTimeout: "30"


### PR DESCRIPTION
## 背景

- longhornの設定を #26 で変えたが、driftしていたのでその状態に合わせる