### PR TITLE
fix: Runnerの起動待ちを短縮

### DIFF
--- a/k8s/apps/forgejo-runner/README.md
+++ b/k8s/apps/forgejo-runner/README.md
@@ -2,6 +2,7 @@
 
 KEDAが`ubuntu-latest`ラベルの待機ジョブ数を監視し、ジョブごとにForgejo Runner Podを作成する。
 待機ジョブがない場合、Runner Podは0個になる。
+`actions/checkout`などの省略形式のActionは、Forgejo本体の設定によりGitHubから取得する。
 
 Runnerは公式イメージの`one-job`モードで動作する。
 各Podは専用のDocker-in-Docker daemonを持ち、別のジョブやクラスタノードのDocker daemonを共有しない。

--- a/k8s/apps/forgejo-runner/resources/scaled-job.yaml
+++ b/k8s/apps/forgejo-runner/resources/scaled-job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: forgejo-runner
   namespace: forgejo-runner
 spec:
-  pollingInterval: 30
+  pollingInterval: 5
   minReplicaCount: 0
   maxReplicaCount: 5
   successfulJobsHistoryLimit: 3

--- a/k8s/apps/forgejo/kustomization.yaml
+++ b/k8s/apps/forgejo/kustomization.yaml
@@ -162,6 +162,8 @@ helmCharts:
           indexer:
             ISSUE_INDEXER_TYPE: db
             REPO_INDEXER_ENABLED: false
+          actions:
+            DEFAULT_ACTIONS_URL: https://github.com
           metrics:
             ENABLED: true
 


### PR DESCRIPTION

30s->5sに短縮
省略形式のActionはforgejo.orgではなくgithubから落とす